### PR TITLE
Removing libraries to test windows installation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -35,7 +35,7 @@ requirements:
     - pathlib >=1.0.1
     - psutil >=5.9.1
     - pydot ==1.3.0
-    - pyjwt ==2.2.0
+    - pyjwt ==2.4.0
     - pympler ==0.9
     - python >=3.7
     - regex
@@ -47,9 +47,7 @@ requirements:
     - tensorflow >=2.5.0
     - tf2onnx
     - pytorch >=1.8.1
-    - urllib3 ==1.25.11
     - python-wget ==3.2
-    - xgboost >=0.90
     - dill
 
 test:


### PR DESCRIPTION
Removing `Xgboost` , `urllib33` and updating `pyjwt` to latest version.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
