### PR TITLE
Revert all packages back into `meta.yaml`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -23,6 +23,7 @@ requirements:
     - astunparse ==1.6.3
     - boto3 ==1.18.2
     - botocore ==1.21.2
+    - dill
     - docker-py ==5.0.0
     - ipython
     - jinja2
@@ -31,21 +32,25 @@ requirements:
     - onnx >=1.9.0
     - onnxconverter-common >=1.7.0
     - onnxmltools >=1.6.1
+    - onnxruntime >=1.7.0
     - pathlib >=1.0.1
     - psutil >=5.9.1
     - pydot ==1.3.0
     - pyjwt ==2.4.0
     - pympler ==0.9
     - python >=3.7
+    - python-wget ==3.2
+    - pytorch >=1.8.1
     - regex
     - requests
     - scikit-learn ==0.24.2
     - seaborn >=0.11.2
     - shortuuid >=1.0.8
     - skl2onnx >=1.8.0
-    - pytorch >=1.8.1
-    - python-wget ==3.2
-    - dill
+    - tensorflow >=2.5.0
+    - tf2onnx
+    - urllib3 ==1.25.11
+    - xgboost >=0.90
 
 test:
   imports:


### PR DESCRIPTION
After testing installations on different platforms ,  we have decided to only support conda installation for mac and linux.

Windows installations should be done via pip.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
