### PR TITLE
Setting lower bound instead of specific version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -24,6 +24,7 @@ requirements:
     - boto3 ==1.18.2
     - botocore ==1.21.2
     - dill
+    - docker-py >=5.0.0
     - ipython
     - importlib-resources
     - jinja2
@@ -35,7 +36,7 @@ requirements:
     - onnxruntime >=1.7.0
     - pathlib >=1.0.1
     - psutil >=5.9.1
-    - pydot ==1.3.0
+    - pydot >=1.3.0
     - pyjwt ==2.4.0
     - pympler ==0.9
     - python >=3.7


### PR DESCRIPTION
  ```
         __  ______ ___  ____ _____ ___  / /_  ____ _
         / / / / __ `__ \/ __ `/ __ `__ \/ __ \/ __ `/
        / /_/ / / / / / / /_/ / / / / / / /_/ / /_/ /
       / .___/_/ /_/ /_/\__,_/_/ /_/ /_/_.___/\__,_/
      /_/

conda-forge/osx-arm64                                       Using cache
conda-forge/noarch                                          Using cache
pkgs/main/osx-arm64                                         Using cache
pkgs/main/noarch                                            Using cache
pkgs/r/osx-arm64                                            Using cache
pkgs/r/noarch                                               Using cache


No entries matching "pydot==1.3.0" found
```


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
